### PR TITLE
feat: support multiple DTO signatures

### DIFF
--- a/chain-api/src/utils/generate-schema.spec.ts
+++ b/chain-api/src/utils/generate-schema.spec.ts
@@ -93,13 +93,27 @@ const expectedTestDtoSchema = {
       description: "Quantity used in some place to support some feature. Number provided as a string.",
       type: "string"
     },
-    signerAddress: {
-      description: "Address of the user who signed the DTO. Typically Ethereum or TON address.",
+    signature: {
+      description: expect.stringContaining("Signature of the DTO signed with caller's private key"),
       minLength: 1,
       type: "string"
     },
-    signature: {
-      description: expect.stringContaining("Signature of the DTO signed with caller's private key"),
+    signatures: {
+      items: {
+        properties: {
+          signature: { minLength: 1, type: "string" },
+          signerAddress: { minLength: 1, type: "string" },
+          signerPublicKey: { minLength: 1, type: "string" }
+        },
+        required: ["signature"],
+        type: "object"
+      },
+      maxItems: 10,
+      minItems: 1,
+      type: "array"
+    },
+    signerAddress: {
+      description: "Address of the user who signed the DTO. Typically Ethereum or TON address.",
       minLength: 1,
       type: "string"
     },

--- a/chain-api/src/utils/signatures/getPayloadToSign.spec.ts
+++ b/chain-api/src/utils/signatures/getPayloadToSign.spec.ts
@@ -26,9 +26,14 @@ describe("getPayloadToSign", () => {
     expect(toSign).toEqual('{"a":3,"b":[{"x":4,"y":5,"z":6},7],"c":8}');
   });
 
-  it("should ignore 'signature' and 'trace' fields", () => {
+  it("should ignore 'signature', 'signatures' and 'trace' fields", () => {
     // Given
-    const obj = { c: 8, signature: "to-be-ignored", trace: 3 };
+    const obj = {
+      c: 8,
+      signature: "to-be-ignored",
+      signatures: [{ signature: "also-ignored" }],
+      trace: 3
+    };
 
     // When
     const toSign = getPayloadToSign(obj);

--- a/chain-api/src/utils/signatures/getPayloadToSign.ts
+++ b/chain-api/src/utils/signatures/getPayloadToSign.ts
@@ -43,6 +43,6 @@ export function getPayloadToSign(obj: object): string {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { signature, trace, ...plain } = instanceToPlain(obj);
+  const { signature, signatures, trace, ...plain } = instanceToPlain(obj);
   return serialize(plain);
 }


### PR DESCRIPTION
## Summary
- add MultiSignature structure and signatures array to DTOs
- exclude signatures from serialized payloads
- support adding and verifying multiple signatures

## Testing
- `npm test --workspace chain-api`
- `npx nx run chain-api:lint` *(fails: NotImplementedError is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b1185126248330a8ef82d7f3e34d64