### PR TITLE
feat(chain-api): add multi-signature support

### DIFF
--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -21,7 +21,6 @@ import {
   IsOptional,
   Max,
   Min,
-  MinLength,
   ValidateNested,
   ValidationError,
   validate
@@ -176,7 +175,7 @@ export class ChainCallDTO {
   public signature?: string;
 
   @JSONSchema({
-    description: "Array of signatures authorizing this DTO. Each entry may include signer details." 
+    description: "Array of signatures authorizing this DTO. Each entry may include signer details."
   })
   @IsOptional()
   @ValidateNested({ each: true })

--- a/chain-api/src/utils/generate-schema.spec.ts
+++ b/chain-api/src/utils/generate-schema.spec.ts
@@ -112,11 +112,11 @@ const expectedTestDtoSchema = {
           signerPublicKey: { minLength: 1, type: "string" }
         },
         required: ["signature"],
-        type: "object",
+        type: "object"
       },
       maxItems: 10,
       minItems: 1,
-      type: "array",
+      type: "array"
     },
     signerPublicKey: {
       description: "Public key of the user who signed the DTO.",

--- a/chain-api/src/utils/generate-schema.spec.ts
+++ b/chain-api/src/utils/generate-schema.spec.ts
@@ -103,6 +103,21 @@ const expectedTestDtoSchema = {
       minLength: 1,
       type: "string"
     },
+    signatures: {
+      description: "Array of signatures authorizing this DTO. Each entry may include signer details.",
+      items: {
+        properties: {
+          signature: { minLength: 1, type: "string" },
+          signerAddress: { minLength: 1, type: "string" },
+          signerPublicKey: { minLength: 1, type: "string" }
+        },
+        required: ["signature"],
+        type: "object",
+      },
+      maxItems: 10,
+      minItems: 1,
+      type: "array",
+    },
     signerPublicKey: {
       description: "Public key of the user who signed the DTO.",
       minLength: 1,

--- a/chain-api/src/utils/serialize.spec.ts
+++ b/chain-api/src/utils/serialize.spec.ts
@@ -61,6 +61,12 @@ it("should sort fields", () => {
   expect(serialized).toEqual('{"a":3,"b":[{"x":4,"y":5,"z":6},7],"c":8}');
 });
 
+it("should omit selected keys", () => {
+  const obj = { a: 1, b: 2, c: 3 };
+  const serialized = serialize(obj, ["b"]);
+  expect(serialized).toEqual('{"a":1,"c":3}');
+});
+
 // Known issue, we used `sort-keys-recursive` before, which does sort arrays
 it("should not sort arrays", () => {
   // Given

--- a/chain-api/src/utils/serialize.ts
+++ b/chain-api/src/utils/serialize.ts
@@ -35,10 +35,13 @@ export default function serialize(object: unknown, keysToOmit: string[] = []) {
       return Object.keys(value as Record<string, unknown>)
         .filter((k) => !keysToOmit.includes(k))
         .sort()
-        .reduce((acc, key) => {
-          acc[key] = omitKeys((value as Record<string, unknown>)[key]);
-          return acc;
-        }, {} as Record<string, unknown>);
+        .reduce(
+          (acc, key) => {
+            acc[key] = omitKeys((value as Record<string, unknown>)[key]);
+            return acc;
+          },
+          {} as Record<string, unknown>
+        );
     } else {
       return value;
     }

--- a/chain-api/src/utils/serialize.ts
+++ b/chain-api/src/utils/serialize.ts
@@ -24,8 +24,25 @@ import stringify from "json-stringify-deterministic";
  * for more details.
  *
  * @param object
+ * @param keysToOmit
  * @returns unknown
  */
-export default function serialize(object: unknown) {
-  return stringify(instanceToPlain(object));
+export default function serialize(object: unknown, keysToOmit: string[] = []) {
+  const omitKeys = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+      return value.map(omitKeys);
+    } else if (value && typeof value === "object") {
+      return Object.keys(value as Record<string, unknown>)
+        .filter((k) => !keysToOmit.includes(k))
+        .sort()
+        .reduce((acc, key) => {
+          acc[key] = omitKeys((value as Record<string, unknown>)[key]);
+          return acc;
+        }, {} as Record<string, unknown>);
+    } else {
+      return value;
+    }
+  };
+
+  return stringify(omitKeys(instanceToPlain(object)));
 }

--- a/chain-api/src/utils/signatures/getPayloadToSign.spec.ts
+++ b/chain-api/src/utils/signatures/getPayloadToSign.spec.ts
@@ -26,9 +26,14 @@ describe("getPayloadToSign", () => {
     expect(toSign).toEqual('{"a":3,"b":[{"x":4,"y":5,"z":6},7],"c":8}');
   });
 
-  it("should ignore 'signature' and 'trace' fields", () => {
+  it("should ignore 'signature', 'signatures' and 'trace' fields", () => {
     // Given
-    const obj = { c: 8, signature: "to-be-ignored", trace: 3 };
+    const obj = {
+      c: 8,
+      signature: "to-be-ignored",
+      signatures: [{ signature: "ignored-too" }],
+      trace: 3
+    };
 
     // When
     const toSign = getPayloadToSign(obj);

--- a/chain-api/src/utils/signatures/getPayloadToSign.ts
+++ b/chain-api/src/utils/signatures/getPayloadToSign.ts
@@ -12,8 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { instanceToPlain } from "class-transformer";
-
 import { TypedDataEncoder } from "../../ethers/hash/typed-data";
 import serialize from "../serialize";
 
@@ -42,7 +40,5 @@ export function getPayloadToSign(obj: object): string {
     return getEIP712PayloadToSign(obj);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { signature, trace, ...plain } = instanceToPlain(obj);
-  return serialize(plain);
+  return serialize(obj, ["signature", "signatures", "trace"]);
 }


### PR DESCRIPTION
## Summary
- extend ChainCallDTO with MultiSignature array and helpers to add and verify multiple signatures
- ignore signature fields during payload serialization for deterministic signing
- document and test multi-signature behavior

## Testing
- `npx jest -c chain-api/jest.config.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b1185126248330a8ef82d7f3e34d64