### PR TITLE
feat: add multi-signature utilities

### DIFF
--- a/chain-api/src/utils/signatures/eth.spec.ts
+++ b/chain-api/src/utils/signatures/eth.spec.ts
@@ -172,6 +172,18 @@ describe("signatures", () => {
     expect(actualSignature).toEqual(derSignature);
   });
 
+  it("should sign and verify payload buffers", () => {
+    const privateKeyBuffer = Buffer.from(privateKey, "hex");
+    const publicKeyBuffer = Buffer.from(publicKey, "hex");
+    const payloadBuffer = Buffer.from(getPayloadToSign(payload));
+
+    const sig = signatures.signMessage(privateKeyBuffer, payloadBuffer);
+    expect(sig).toEqual(signature);
+
+    const valid = signatures.verifySignature(sig, payloadBuffer, publicKeyBuffer);
+    expect(valid).toBeTruthy();
+  });
+
   it("should parse signature", async () => {
     // When
     const parsed = signatures.parseSecp256k1Signature(signature);

--- a/chain-api/src/utils/signatures/eth.ts
+++ b/chain-api/src/utils/signatures/eth.ts
@@ -350,6 +350,16 @@ function calculateKeccak256(data: Buffer): Buffer {
   return Buffer.from(keccak256.digest(data));
 }
 
+function signMessage(privateKey: Buffer, payload: Buffer): string {
+  return signSecp256k1(calculateKeccak256(payload), privateKey);
+}
+
+function verifySignature(signature: string, payload: Buffer, publicKey: Buffer): boolean {
+  const signatureObj = parseSecp256k1Signature(signature);
+  const dataHash = calculateKeccak256(payload);
+  return isValidSecp256k1Signature(signatureObj, dataHash, publicKey);
+}
+
 function getSignature(obj: object, privateKey: Buffer): string {
   const data = Buffer.from(getPayloadToSign(obj));
   return signSecp256k1(calculateKeccak256(data), privateKey);
@@ -447,6 +457,8 @@ export default {
   getNonCompactHexPublicKey,
   getEthAddress,
   getPublicKey,
+  signMessage,
+  verifySignature,
   getSignature,
   getDERSignature,
   isChecksumedEthAddress,

--- a/chain-api/src/utils/signatures/index.ts
+++ b/chain-api/src/utils/signatures/index.ts
@@ -15,6 +15,7 @@
 import eth from "./eth";
 import { getPayloadToSign } from "./getPayloadToSign";
 import ton from "./ton";
+import multiSig from "./multiSig";
 
 export enum SigningScheme {
   ETH = "ETH",
@@ -24,5 +25,6 @@ export enum SigningScheme {
 export default {
   ...eth,
   ton,
+  multiSig,
   getPayloadToSign
 } as const;

--- a/chain-api/src/utils/signatures/multiSig.spec.ts
+++ b/chain-api/src/utils/signatures/multiSig.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Gala Games Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import signatures, { SigningScheme } from "./";
+
+describe("multiSig", () => {
+  it("signs and verifies multiple ETH signatures", () => {
+    const privateKey1 = Buffer.from(
+      "3b19099e96dccf44e1dfc13c89c7e490d902a96b0791faf185e194ae0e71786d",
+      "hex"
+    );
+    const pair2 = signatures.genKeyPair();
+    const privateKey2 = Buffer.from(pair2.privateKey, "hex");
+    const payload = Buffer.from("hello multi");
+
+    const signed = signatures.multiSig.sign(payload, SigningScheme.ETH, [privateKey1, privateKey2], true);
+    expect(signed).toHaveLength(2);
+
+    const verify = signatures.multiSig.verify(
+      payload,
+      SigningScheme.ETH,
+      signed.map(({ sig, pk }) => ({ sig, pk })),
+      true
+    );
+    verify.forEach((v, idx) => {
+      expect(v.ok).toBeTruthy();
+      expect(v.address).toEqual(signed[idx].address);
+    });
+  });
+
+  it("signs and verifies multiple TON signatures", async () => {
+    const key1 = Buffer.from(
+      "wa50qZmPeW5qyETdnYPSRLzdOD6Fv3R/drWgPYkcy6aRiZKhoZ29Lc2MtqJkRVTjR7gDJgXR0qGaPbMFNszGPw==",
+      "base64"
+    );
+    const pair2 = await signatures.ton.genKeyPair();
+    const payload = Buffer.from("ton multi");
+
+    const signed = signatures.multiSig.sign(payload, SigningScheme.TON, [key1, pair2.secretKey], true);
+    expect(signed).toHaveLength(2);
+
+    const verify = signatures.multiSig.verify(
+      payload,
+      SigningScheme.TON,
+      signed.map(({ sig, pk }) => ({ sig, pk })),
+      true
+    );
+    verify.forEach((v, idx) => {
+      expect(v.ok).toBeTruthy();
+      expect(v.address).toEqual(signed[idx].address);
+    });
+  });
+});

--- a/chain-api/src/utils/signatures/multiSig.ts
+++ b/chain-api/src/utils/signatures/multiSig.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Gala Games Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import eth from "./eth";
+import ton from "./ton";
+
+type Scheme = "ETH" | "TON";
+
+interface SignedPayload {
+  sig: string | Buffer;
+  pk: Buffer;
+  address?: string;
+}
+
+interface VerifyInput {
+  sig: string | Buffer;
+  pk: Buffer;
+}
+
+interface VerifyResult {
+  ok: boolean;
+  address?: string;
+}
+
+function getTonPublicKey(secretKey: Buffer): Buffer {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { keyPairFromSecretKey } = require("@ton/crypto");
+  return keyPairFromSecretKey(secretKey).publicKey;
+}
+
+function sign(payload: Buffer, scheme: Scheme, privateKeys: Buffer[], includeAddress = false): SignedPayload[] {
+  return privateKeys.map((sk) => {
+    if (scheme === "ETH") {
+      const sig = eth.signMessage(sk, payload);
+      const pk = Buffer.from(eth.getPublicKey(sk.toString("hex")), "hex");
+      const address = includeAddress ? eth.getEthAddress(pk.toString("hex")) : undefined;
+      return address ? { sig, pk, address } : { sig, pk };
+    } else if (scheme === "TON") {
+      const sig = ton.signMessage(sk, payload);
+      const pk = getTonPublicKey(sk);
+      const address = includeAddress ? ton.getTonAddress(pk) : undefined;
+      return address ? { sig, pk, address } : { sig, pk };
+    }
+    throw new Error(`Unsupported signing scheme: ${scheme}`);
+  });
+}
+
+function verify(payload: Buffer, scheme: Scheme, pairs: VerifyInput[], includeAddress = false): VerifyResult[] {
+  return pairs.map(({ sig, pk }) => {
+    if (scheme === "ETH") {
+      const ok = eth.verifySignature(sig as string, payload, pk);
+      const address = includeAddress ? eth.getEthAddress(pk.toString("hex")) : undefined;
+      return address ? { ok, address } : { ok };
+    } else if (scheme === "TON") {
+      const ok = ton.verifySignature(sig as Buffer, payload, pk);
+      const address = includeAddress ? ton.getTonAddress(pk) : undefined;
+      return address ? { ok, address } : { ok };
+    }
+    throw new Error(`Unsupported signing scheme: ${scheme}`);
+  });
+}
+
+export default { sign, verify } as const;

--- a/chain-api/src/utils/signatures/ton.spec.ts
+++ b/chain-api/src/utils/signatures/ton.spec.ts
@@ -73,6 +73,20 @@ it("should sign and verify TON signature", async () => {
   expect(isValid).toBeTruthy();
 });
 
+it("should sign and verify buffers", () => {
+  const keyPair = {
+    secretKey: Buffer.from(
+      "wa50qZmPeW5qyETdnYPSRLzdOD6Fv3R/drWgPYkcy6aRiZKhoZ29Lc2MtqJkRVTjR7gDJgXR0qGaPbMFNszGPw==",
+      "base64"
+    ),
+    publicKey: Buffer.from("kYmSoaGdvS3NjLaiZEVU40e4AyYF0dKhmj2zBTbMxj8=", "base64")
+  };
+  const payload = Buffer.from("hello ton");
+  const sig = ton.signMessage(keyPair.secretKey, payload);
+  const valid = ton.verifySignature(sig, payload, keyPair.publicKey);
+  expect(valid).toBeTruthy();
+});
+
 it("should validate supported TON address", () => {
   // Given
   const validBouncable = "EQAWzEKcdnykvXfUNouqdS62tvrp32bCxuKS6eQrS6ISgcLo";

--- a/chain-api/src/utils/signatures/ton.ts
+++ b/chain-api/src/utils/signatures/ton.ts
@@ -98,6 +98,18 @@ function splitDataIntoCells(data: Buffer) {
 // To achieve it, we need to use safeSign and safeSignVerify functions instead of sign and signVerify.
 // They transform the payload accordingly.
 //
+function signMessage(privateKey: Buffer, payload: Buffer): Buffer {
+  const { safeSign } = importTonOrReject().ton;
+  const cell = splitDataIntoCells(Buffer.from(payload));
+  return safeSign(cell, privateKey);
+}
+
+function verifySignature(signature: Buffer, payload: Buffer, publicKey: Buffer): boolean {
+  const { safeSignVerify } = importTonOrReject().ton;
+  const cell = splitDataIntoCells(Buffer.from(payload));
+  return safeSignVerify(cell, signature, publicKey);
+}
+
 function getSignature(obj: object, privateKey: Buffer, seed: string | undefined): Buffer {
   const { safeSign } = importTonOrReject().ton;
   const data = getPayloadToSign(obj);
@@ -119,6 +131,8 @@ function isValidSignature(
 
 export default {
   genKeyPair,
+  signMessage,
+  verifySignature,
   getSignature,
   getTonAddress,
   isValidTonAddress,


### PR DESCRIPTION
## Summary
- expose buffer-level signMessage and verifySignature for ETH and TON
- add multiSig module to sign/verify payloads with multiple keys and compute addresses
- test multi-signature flows and buffer-based primitives

## Testing
- `npx jest -c chain-api/jest.config.ts chain-api/src/utils/signatures/eth.spec.ts chain-api/src/utils/signatures/ton.spec.ts chain-api/src/utils/signatures/multiSig.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b12bce74908330a4b373f8313c8c17