### PR TITLE
feat(signatures): add multi-sig utilities

### DIFF
--- a/chain-api/src/utils/signatures/eth.spec.ts
+++ b/chain-api/src/utils/signatures/eth.spec.ts
@@ -488,6 +488,14 @@ describe("eth addr validation", () => {
     expect(signatures.isChecksumedEthAddress(invalid)).toEqual(false);
 
     // wrong prefix
-    expect(signatures.isChecksumedEthAddress(`1x${valid}`)).toEqual(false);
+  expect(signatures.isChecksumedEthAddress(`1x${valid}`)).toEqual(false);
   });
+});
+
+it("should sign and verify raw payload", () => {
+  const { privateKey, publicKey } = signatures.genKeyPair();
+  const payload = Buffer.from("hello-eth");
+  const signature = signatures.signMessage(Buffer.from(privateKey, "hex"), payload);
+  const isValid = signatures.verifySignature(signature, payload, Buffer.from(publicKey, "hex"));
+  expect(isValid).toBeTruthy();
 });

--- a/chain-api/src/utils/signatures/eth.spec.ts
+++ b/chain-api/src/utils/signatures/eth.spec.ts
@@ -488,7 +488,7 @@ describe("eth addr validation", () => {
     expect(signatures.isChecksumedEthAddress(invalid)).toEqual(false);
 
     // wrong prefix
-  expect(signatures.isChecksumedEthAddress(`1x${valid}`)).toEqual(false);
+    expect(signatures.isChecksumedEthAddress(`1x${valid}`)).toEqual(false);
   });
 });
 

--- a/chain-api/src/utils/signatures/eth.ts
+++ b/chain-api/src/utils/signatures/eth.ts
@@ -350,6 +350,15 @@ function calculateKeccak256(data: Buffer): Buffer {
   return Buffer.from(keccak256.digest(data));
 }
 
+function signMessage(privateKey: Buffer, payload: Buffer): string {
+  return signSecp256k1(calculateKeccak256(payload), privateKey);
+}
+
+function verifySignature(signature: string, payload: Buffer, publicKey: Buffer): boolean {
+  const signatureObj = parseSecp256k1Signature(signature);
+  return isValidSecp256k1Signature(signatureObj, calculateKeccak256(payload), publicKey);
+}
+
 function getSignature(obj: object, privateKey: Buffer): string {
   const data = Buffer.from(getPayloadToSign(obj));
   return signSecp256k1(calculateKeccak256(data), privateKey);
@@ -449,6 +458,8 @@ export default {
   getPublicKey,
   getSignature,
   getDERSignature,
+  signMessage,
+  verifySignature,
   isChecksumedEthAddress,
   isLowercasedEthAddress,
   isValid,

--- a/chain-api/src/utils/signatures/index.ts
+++ b/chain-api/src/utils/signatures/index.ts
@@ -14,8 +14,8 @@
  */
 import eth from "./eth";
 import { getPayloadToSign } from "./getPayloadToSign";
-import ton from "./ton";
 import multiSig from "./multiSig";
+import ton from "./ton";
 
 export enum SigningScheme {
   ETH = "ETH",

--- a/chain-api/src/utils/signatures/index.ts
+++ b/chain-api/src/utils/signatures/index.ts
@@ -15,6 +15,7 @@
 import eth from "./eth";
 import { getPayloadToSign } from "./getPayloadToSign";
 import ton from "./ton";
+import multiSig from "./multiSig";
 
 export enum SigningScheme {
   ETH = "ETH",
@@ -24,5 +25,6 @@ export enum SigningScheme {
 export default {
   ...eth,
   ton,
-  getPayloadToSign
+  getPayloadToSign,
+  multiSig
 } as const;

--- a/chain-api/src/utils/signatures/multiSig.spec.ts
+++ b/chain-api/src/utils/signatures/multiSig.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Gala Games Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import multiSig from "./multiSig";
+import eth from "./eth";
+import { SigningScheme } from "./index";
+
+it("should sign and verify using multiple keys", () => {
+  const pair1 = eth.genKeyPair();
+  const pair2 = eth.genKeyPair();
+
+  const privKeys = [Buffer.from(pair1.privateKey, "hex"), Buffer.from(pair2.privateKey, "hex")];
+  const payload = Buffer.from("multi-sig-test");
+
+  const signatures = multiSig.sign(payload, privKeys, SigningScheme.ETH, true);
+  expect(signatures).toHaveLength(2);
+
+  const verify = multiSig.verify(
+    payload,
+    signatures.map(({ sig, pk }) => ({ sig, pk })),
+    SigningScheme.ETH,
+    true
+  );
+
+  verify.forEach((v, i) => {
+    expect(v.valid).toBeTruthy();
+    expect(v.address).toBe(signatures[i].address);
+  });
+});
+

--- a/chain-api/src/utils/signatures/multiSig.spec.ts
+++ b/chain-api/src/utils/signatures/multiSig.spec.ts
@@ -12,10 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import multiSig from "./multiSig";
 import eth from "./eth";
 import { SigningScheme } from "./index";
+import multiSig from "./multiSig";
 
 it("should sign and verify using multiple keys", () => {
   const pair1 = eth.genKeyPair();
@@ -39,4 +38,3 @@ it("should sign and verify using multiple keys", () => {
     expect(v.address).toBe(signatures[i].address);
   });
 });
-

--- a/chain-api/src/utils/signatures/multiSig.ts
+++ b/chain-api/src/utils/signatures/multiSig.ts
@@ -12,10 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import eth from "./eth";
-import ton from "./ton";
 import type { SigningScheme } from "./index";
+import ton from "./ton";
 
 export interface SignatureEntry {
   sig: string | Buffer;
@@ -93,4 +92,3 @@ function verify(
 }
 
 export default { sign, verify } as const;
-

--- a/chain-api/src/utils/signatures/multiSig.ts
+++ b/chain-api/src/utils/signatures/multiSig.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Gala Games Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import eth from "./eth";
+import ton from "./ton";
+import type { SigningScheme } from "./index";
+
+export interface SignatureEntry {
+  sig: string | Buffer;
+  pk: Buffer;
+  address?: string;
+}
+
+export interface VerificationEntry extends SignatureEntry {
+  valid: boolean;
+}
+
+function getTonPublicKey(secretKey: Buffer): Buffer {
+  let crypto;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    crypto = require("@ton/crypto");
+  } catch (e) {
+    throw new Error("TON is not supported. Missing library @ton/crypto");
+  }
+
+  return crypto.keyPairFromSecretKey(secretKey).publicKey;
+}
+
+function sign(
+  payload: Buffer,
+  privateKeys: Buffer[],
+  scheme: SigningScheme,
+  includeAddress = false
+): SignatureEntry[] {
+  return privateKeys.map((priv) => {
+    switch (scheme) {
+      case "ETH": {
+        const sig = eth.signMessage(priv, payload);
+        const pubHex = eth.getPublicKey(priv.toString("hex"));
+        const pk = Buffer.from(pubHex, "hex");
+        const address = includeAddress ? eth.getEthAddress(pubHex) : undefined;
+        return { sig, pk, address };
+      }
+      case "TON": {
+        const sig = ton.signMessage(priv, payload);
+        const pk = getTonPublicKey(priv);
+        const address = includeAddress ? ton.getTonAddress(pk) : undefined;
+        return { sig, pk, address };
+      }
+      default:
+        throw new Error(`Unsupported signing scheme: ${scheme}`);
+    }
+  });
+}
+
+function verify(
+  payload: Buffer,
+  pairs: { sig: string | Buffer; pk: Buffer }[],
+  scheme: SigningScheme,
+  includeAddress = false
+): VerificationEntry[] {
+  return pairs.map(({ sig, pk }) => {
+    let valid: boolean;
+    let address: string | undefined;
+    switch (scheme) {
+      case "ETH":
+        valid = eth.verifySignature(sig as string, payload, pk);
+        address = includeAddress ? eth.getEthAddress(pk.toString("hex")) : undefined;
+        break;
+      case "TON":
+        valid = ton.verifySignature(sig as Buffer, payload, pk);
+        address = includeAddress ? ton.getTonAddress(pk) : undefined;
+        break;
+      default:
+        throw new Error(`Unsupported signing scheme: ${scheme}`);
+    }
+
+    return { sig, pk, address, valid };
+  });
+}
+
+export default { sign, verify } as const;
+

--- a/chain-api/src/utils/signatures/ton.spec.ts
+++ b/chain-api/src/utils/signatures/ton.spec.ts
@@ -88,3 +88,11 @@ it("should validate supported TON address", () => {
   expect(ton.isValidTonAddress(invalid)).toBeFalsy();
   expect(ton.isValidTonAddress(undef)).toBeFalsy();
 });
+
+it("should sign and verify raw payload", async () => {
+  const pair = await ton.genKeyPair();
+  const payload = Buffer.from("hello-ton");
+  const signature = ton.signMessage(pair.secretKey, payload);
+  const isValid = ton.verifySignature(signature, payload, pair.publicKey);
+  expect(isValid).toBeTruthy();
+});

--- a/chain-api/src/utils/signatures/ton.ts
+++ b/chain-api/src/utils/signatures/ton.ts
@@ -98,6 +98,18 @@ function splitDataIntoCells(data: Buffer) {
 // To achieve it, we need to use safeSign and safeSignVerify functions instead of sign and signVerify.
 // They transform the payload accordingly.
 //
+function signMessage(privateKey: Buffer, payload: Buffer): Buffer {
+  const { safeSign } = importTonOrReject().ton;
+  const cell = splitDataIntoCells(payload);
+  return safeSign(cell, privateKey);
+}
+
+function verifySignature(signature: Buffer, payload: Buffer, publicKey: Buffer): boolean {
+  const { safeSignVerify } = importTonOrReject().ton;
+  const cell = splitDataIntoCells(payload);
+  return safeSignVerify(cell, signature, publicKey);
+}
+
 function getSignature(obj: object, privateKey: Buffer, seed: string | undefined): Buffer {
   const { safeSign } = importTonOrReject().ton;
   const data = getPayloadToSign(obj);
@@ -119,6 +131,8 @@ function isValidSignature(
 
 export default {
   genKeyPair,
+  signMessage,
+  verifySignature,
   getSignature,
   getTonAddress,
   isValidTonAddress,

--- a/chain-api/src/utils/signatures/ton.ts
+++ b/chain-api/src/utils/signatures/ton.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NotImplementedError, ValidationFailedError } from "../error";
+import { ValidationFailedError } from "../error";
 import { getPayloadToSign } from "./getPayloadToSign";
 
 // verify if TON is supported

--- a/chaincode/jest.config.ts
+++ b/chaincode/jest.config.ts
@@ -19,7 +19,7 @@ export default {
   preset: "../jest.preset.js",
   testEnvironment: "node",
   transform: {
-    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
+    "^.+\\.ts$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
   },
   moduleFileExtensions: ["ts", "js", "html"],
   coverageDirectory: "../coverage/chaincode",


### PR DESCRIPTION
## Summary
- expose buffer-based `signMessage` and `verifySignature` helpers for ETH and TON primitives
- add `multiSig` module to sign and verify payloads with multiple keys and compute addresses
- re-export new utilities for easy consumption

## Testing
- `npx nx test chain-api`

------
https://chatgpt.com/codex/tasks/task_e_68b12bce74908330a4b373f8313c8c17