### PR TITLE
feat: support multisig validation

### DIFF
--- a/chaincode/src/contracts/GalaTransaction.multisig.spec.ts
+++ b/chaincode/src/contracts/GalaTransaction.multisig.spec.ts
@@ -1,0 +1,77 @@
+import {
+  ChainCallDTO,
+  ForbiddenError,
+  GalaChainResponse,
+  UserAlias,
+  UserProfile,
+  UserRole
+} from "@gala-chain/api";
+
+import { GalaContract } from "./GalaContract";
+import { EVALUATE, GalaTransaction } from "./GalaTransaction";
+import { MissingRoleError } from "./authorize";
+import { GalaChainContext } from "../types";
+
+class MultiSigTestContract extends GalaContract {
+  constructor() {
+    super("MultiSigTestContract", "1.0");
+  }
+
+  @GalaTransaction({ type: EVALUATE, requiredSignatures: 2 })
+  async NeedsTwo(ctx: GalaChainContext, _dto: ChainCallDTO): Promise<void> {
+    return;
+  }
+
+  @GalaTransaction({
+    type: EVALUATE,
+    requiredSignatures: 2,
+    requiredRolesPerSigner: [UserRole.CURATOR]
+  })
+  async NeedsCurators(ctx: GalaChainContext, _dto: ChainCallDTO): Promise<void> {
+    return;
+  }
+}
+
+describe("GalaTransaction multisig validation", () => {
+  it("enforces required signatures", async () => {
+    const contract = new MultiSigTestContract();
+    const ctx = new GalaChainContext({});
+    ctx.isDryRun = true;
+
+    const user = new UserProfile();
+    user.alias = "client|u1" as UserAlias;
+    user.roles = [UserRole.EVALUATE];
+    ctx.callingUsers = [user];
+
+    const response = await contract.NeedsTwo(ctx, new ChainCallDTO());
+
+    expect(response).toEqual(
+      GalaChainResponse.Error(
+        new ForbiddenError("Requires at least 2 signatures but got 1.", { required: 2, received: 1 })
+      )
+    );
+  });
+
+  it("validates roles for each signer", async () => {
+    const contract = new MultiSigTestContract();
+    const ctx = new GalaChainContext({});
+    ctx.isDryRun = true;
+
+    const user1 = new UserProfile();
+    user1.alias = "client|u1" as UserAlias;
+    user1.roles = [UserRole.CURATOR, UserRole.EVALUATE];
+
+    const user2 = new UserProfile();
+    user2.alias = "client|u2" as UserAlias;
+    user2.roles = [UserRole.EVALUATE];
+
+    ctx.callingUsers = [user1, user2];
+
+    const response = await contract.NeedsCurators(ctx, new ChainCallDTO());
+
+    expect(response).toEqual(
+      GalaChainResponse.Error(new MissingRoleError(user2.alias, user2.roles, [UserRole.CURATOR]))
+    );
+  });
+});
+

--- a/chaincode/src/contracts/authenticate.ts
+++ b/chaincode/src/contracts/authenticate.ts
@@ -17,6 +17,7 @@ import {
   ForbiddenError,
   PublicKey,
   SigningScheme,
+  UserProfile,
   UserProfileWithRoles,
   ValidationFailedError,
   signatures
@@ -101,7 +102,7 @@ export async function authenticate(
   ethAddress?: string;
   tonAddress?: string;
   roles: string[];
-  users: { alias?: string; ethAddress?: string; tonAddress?: string; roles: string[] }[];
+  users: UserProfile[];
   minSignatures: number;
 }> {
   if (!dto || !dto.signatures || dto.signatures.length === 0) {
@@ -191,12 +192,14 @@ export async function authenticate(
     }
   }
 
-  const callingUsers = users.map((u) => ({
-    alias: u.alias,
-    ethAddress: u.ethAddress,
-    tonAddress: u.tonAddress,
-    roles: u.roles
-  }));
+  const callingUsers: UserProfile[] = users.map((u) => {
+    const p = new UserProfile();
+    p.alias = u.alias;
+    p.ethAddress = u.ethAddress;
+    p.tonAddress = u.tonAddress;
+    p.roles = u.roles;
+    return p;
+  });
 
   ctx.callingUsers = callingUsers;
 


### PR DESCRIPTION
## Summary
- extend GalaChainContext to store multiple calling users and check roles
- allow @GalaTransaction to require a signature threshold and per-signer roles
- add tests covering multisig validation

## Testing
- `npx jest --config chaincode/jest.config.ts` *(fails: ts-node missing)*


------
https://chatgpt.com/codex/tasks/task_e_68b1d974ea888330b321a29c928f66f3