### PR TITLE
feat: validate multiple signatures

### DIFF
--- a/chaincode/src/contracts/authenticate.multisig.spec.ts
+++ b/chaincode/src/contracts/authenticate.multisig.spec.ts
@@ -1,10 +1,11 @@
 import { ChainCallDTO } from "@gala-chain/api";
 import { TestChaincode, TestChaincodeStub } from "@gala-chain/test";
 
+import { PkInvalidSignatureError } from "../services/PublicKeyError";
+import { GalaChainContext } from "../types";
 import { PublicKeyContract } from "./PublicKeyContract";
 import { authenticate } from "./authenticate";
 import { createRegisteredUser } from "./authenticate.testutils.spec";
-import { GalaChainContext } from "../types";
 
 describe("authenticate multisig", () => {
   it("aggregates multiple signers", async () => {
@@ -14,6 +15,7 @@ describe("authenticate multisig", () => {
 
     const dto = new ChainCallDTO();
     dto.sign(user1.privateKey);
+    dto.signerPublicKey = user2.publicKey;
     dto.addSignature(user2.privateKey);
 
     const ctx = new GalaChainContext({});
@@ -27,5 +29,22 @@ describe("authenticate multisig", () => {
     expect(result.users[0].alias).toBe(user1.alias);
     expect(result.users[1].alias).toBe(user2.alias);
     expect(ctx.callingUsers).toEqual(result.users);
+  });
+
+  it("rejects signatures that mismatch declared signer", async () => {
+    const chaincode = new TestChaincode([PublicKeyContract]);
+    const user1 = await createRegisteredUser(chaincode);
+    const user2 = await createRegisteredUser(chaincode);
+
+    const dto = new ChainCallDTO();
+    dto.sign(user1.privateKey);
+    dto.signerAddress = user2.ethAddress;
+    dto.addSignature(user1.privateKey);
+
+    const ctx = new GalaChainContext({});
+    const stub = new TestChaincodeStub([], chaincode.state, {});
+    ctx.setChaincodeStub(stub);
+
+    await expect(authenticate(ctx, dto, 2)).rejects.toThrow(PkInvalidSignatureError);
   });
 });

--- a/chaincode/src/contracts/authenticate.ts
+++ b/chaincode/src/contracts/authenticate.ts
@@ -12,76 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  ChainCallDTO,
-  ForbiddenError,
-  PublicKey,
-  SigningScheme,
-  UserProfile,
-  UserProfileWithRoles,
-  ValidationFailedError,
-  signatures
-} from "@gala-chain/api";
+import { ChainCallDTO, ForbiddenError, UserProfile, ValidationFailedError } from "@gala-chain/api";
 import * as protos from "fabric-protos";
 
-import { PkInvalidSignatureError, PublicKeyService } from "../services";
-import { PkMissingError } from "../services/PublicKeyError";
+import { PublicKeyService } from "../services";
 import { GalaChainContext } from "../types";
 
 class MissingSignatureError extends ValidationFailedError {
   constructor() {
     super("Signature is missing.");
-  }
-}
-
-class RedundantSignerPublicKeyError extends ValidationFailedError {
-  constructor(recovered: string, inDto: string) {
-    super(
-      "Public key is redundant when it can be recovered from the signature, or when the address is provided.",
-      {
-        recovered,
-        inDto
-      }
-    );
-  }
-}
-
-class PublicKeyMismatchError extends ValidationFailedError {
-  constructor(recovered: string, inDto: string) {
-    super("Public key recovered from signature is different from the one provided in dto.", {
-      recovered,
-      inDto
-    });
-  }
-}
-
-class RedundantSignerAddressError extends ValidationFailedError {
-  constructor(recovered: string, inDto: string) {
-    super("Signer address is redundant when it can be recovered from the signature.", {
-      recovered,
-      inDto
-    });
-  }
-}
-
-class AddressMismatchError extends ValidationFailedError {
-  constructor(recovered: string, inDto: string) {
-    super("Signer address recovered from signature is different from the one provided in dto.", {
-      recovered,
-      inDto
-    });
-  }
-}
-
-class MissingSignerError extends ValidationFailedError {
-  constructor(signature: string) {
-    super(`Missing signerPublicKey or signerAddress field in dto. Signature: ${signature}.`, { signature });
-  }
-}
-
-class UserNotRegisteredError extends ValidationFailedError {
-  constructor(userId: string) {
-    super(`User ${userId} is not registered.`, { userId });
   }
 }
 
@@ -114,85 +53,9 @@ export async function authenticate(
     throw new MissingSignatureError();
   }
 
-  const users: UserProfileWithRoles[] = [];
-  const scheme = dto.signing ?? SigningScheme.ETH;
+  const usersWithRoles = await PublicKeyService.ensureSignaturesValid(ctx, dto);
 
-  for (let i = 0; i < dto.signatures.length; i++) {
-    const sig = dto.signatures[i];
-    const signerId = sig.signerAddress ?? sig.signerPublicKey ?? `index ${i}`;
-
-    try {
-      const recoveredPkHex = recoverPublicKey(sig.signature, dto, dto.prefix ?? "");
-
-      if (recoveredPkHex !== undefined) {
-        if (sig.signerPublicKey !== undefined) {
-          const hexKey = signatures.getNonCompactHexPublicKey(sig.signerPublicKey);
-          if (recoveredPkHex !== hexKey) {
-            throw new PublicKeyMismatchError(recoveredPkHex, hexKey);
-          } else {
-            throw new RedundantSignerPublicKeyError(recoveredPkHex, sig.signerPublicKey);
-          }
-        }
-        if (sig.signerAddress !== undefined) {
-          const ethAddress = signatures.getEthAddress(recoveredPkHex);
-          if (sig.signerAddress !== ethAddress) {
-            throw new AddressMismatchError(ethAddress, sig.signerAddress);
-          } else {
-            throw new RedundantSignerAddressError(ethAddress, sig.signerAddress);
-          }
-        }
-        users.push(await getUserProfile(ctx, recoveredPkHex, scheme));
-      } else if (sig.signerAddress !== undefined) {
-        if (sig.signerPublicKey !== undefined) {
-          throw new RedundantSignerPublicKeyError(sig.signerAddress, sig.signerPublicKey);
-        }
-
-        const { profile, publicKey } = await getUserProfileAndPublicKey(ctx, sig.signerAddress);
-
-        const isValid =
-          scheme === SigningScheme.TON
-            ? signatures.ton.isValidSignature(
-                Buffer.from(sig.signature, "base64"),
-                dto,
-                Buffer.from(publicKey.publicKey, "base64"),
-                dto.prefix
-              )
-            : signatures.isValid(sig.signature, dto, publicKey.publicKey);
-
-        if (!isValid) {
-          throw new PkInvalidSignatureError(profile.alias);
-        }
-
-        users.push(profile);
-      } else if (sig.signerPublicKey !== undefined) {
-        const isValid =
-          scheme === SigningScheme.TON
-            ? signatures.ton.isValidSignature(
-                Buffer.from(sig.signature, "base64"),
-                dto,
-                Buffer.from(sig.signerPublicKey, "base64"),
-                dto.prefix
-              )
-            : signatures.isValid(sig.signature, dto, sig.signerPublicKey);
-
-        if (!isValid) {
-          const address = PublicKeyService.getUserAddress(sig.signerPublicKey, scheme);
-          throw new PkInvalidSignatureError(address);
-        }
-
-        users.push(await getUserProfile(ctx, sig.signerPublicKey, scheme));
-      } else {
-        throw new MissingSignerError(sig.signature);
-      }
-    } catch (err) {
-      if (err instanceof Error) {
-        err.message = `${err.message} (signer: ${signerId})`;
-      }
-      throw err;
-    }
-  }
-
-  const callingUsers: UserProfile[] = users.map((u) => {
+  const callingUsers: UserProfile[] = usersWithRoles.map((u) => {
     const p = new UserProfile();
     p.alias = u.alias;
     p.ethAddress = u.ethAddress;
@@ -205,56 +68,6 @@ export async function authenticate(
 
   const first = callingUsers[0];
   return { ...first, users: callingUsers, minSignatures };
-}
-
-async function getUserProfile(
-  ctx: GalaChainContext,
-  publicKey: string,
-  signing: SigningScheme
-): Promise<UserProfileWithRoles> {
-  const address = PublicKeyService.getUserAddress(publicKey, signing);
-  const profile = await PublicKeyService.getUserProfile(ctx, address);
-
-  if (profile === undefined) {
-    if (ctx.config.allowNonRegisteredUsers) {
-      return PublicKeyService.getDefaultUserProfile(publicKey, signing);
-    } else {
-      throw new UserNotRegisteredError(address);
-    }
-  }
-
-  return profile;
-}
-
-async function getUserProfileAndPublicKey(
-  ctx: GalaChainContext,
-  address
-): Promise<{ profile: UserProfileWithRoles; publicKey: PublicKey }> {
-  const profile = await PublicKeyService.getUserProfile(ctx, address);
-
-  if (profile === undefined) {
-    throw new UserNotRegisteredError(address);
-  }
-
-  const publicKey = await PublicKeyService.getPublicKey(ctx, profile.alias);
-
-  if (publicKey === undefined) {
-    throw new PkMissingError(profile.alias);
-  }
-
-  return { profile, publicKey };
-}
-
-function recoverPublicKey(signature: string, dto: ChainCallDTO, prefix = ""): string | undefined {
-  if (dto.signing === SigningScheme.TON) {
-    return undefined;
-  }
-
-  try {
-    return signatures.recoverPublicKey(signature, dto, prefix);
-  } catch (err) {
-    return undefined;
-  }
 }
 
 export async function ensureIsAuthenticatedBy(

--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -23,6 +23,7 @@ import {
   UserAlias,
   UserProfile,
   UserProfileWithRoles,
+  ValidationFailedError,
   asValidUserAlias,
   createValidChainObject,
   normalizePublicKey,
@@ -39,6 +40,20 @@ import {
   ProfileExistsError,
   UserProfileNotFoundError
 } from "./PublicKeyError";
+
+class MissingSignerError extends ValidationFailedError {
+  constructor(signature: string) {
+    super(`Missing signerPublicKey or signerAddress field in dto. Signature: ${signature}.`, {
+      signature
+    });
+  }
+}
+
+class UserNotRegisteredError extends ValidationFailedError {
+  constructor(userId: string) {
+    super(`User ${userId} is not registered.`, { userId });
+  }
+}
 
 export class PublicKeyService {
   private static PK_INDEX_KEY = PK_INDEX_KEY;
@@ -155,6 +170,31 @@ export class PublicKeyService {
     return undefined;
   }
 
+  public static async getUserProfiles(
+    ctx: Context,
+    addresses: string[]
+  ): Promise<UserProfileWithRoles[]> {
+    if (addresses.length === 0) {
+      return [];
+    }
+
+    const keys = addresses.map((a) => PublicKeyService.getUserProfileKey(ctx, a));
+    const states = await Promise.all(keys.map((k) => ctx.stub.getState(k)));
+    const result: UserProfileWithRoles[] = [];
+
+    for (const data of states) {
+      if (data.length > 0) {
+        const userProfile = ChainObject.deserialize<UserProfile>(UserProfile, data.toString());
+        if (userProfile.roles === undefined) {
+          userProfile.roles = Array.from(UserProfile.DEFAULT_ROLES);
+        }
+        result.push(userProfile as UserProfileWithRoles);
+      }
+    }
+
+    return result;
+  }
+
   public static getDefaultUserProfile(publicKey: string, signing: SigningScheme): UserProfileWithRoles {
     const address = this.getUserAddress(publicKey, signing);
     const profile = new UserProfile();
@@ -213,6 +253,91 @@ export class PublicKeyService {
     }
 
     return pk;
+  }
+
+  public static async ensureSignaturesValid(
+    ctx: GalaChainContext,
+    dto: ChainCallDTO
+  ): Promise<UserProfileWithRoles[]> {
+    if (!dto.signatures || dto.signatures.length === 0) {
+      return [];
+    }
+
+    const scheme = dto.signing ?? SigningScheme.ETH;
+
+    const addresses: string[] = [];
+    const publicKeys: (string | undefined)[] = [];
+
+    for (const sig of dto.signatures) {
+      if (sig.signerAddress) {
+        addresses.push(sig.signerAddress);
+        publicKeys.push(undefined);
+      } else if (sig.signerPublicKey) {
+        addresses.push(PublicKeyService.getUserAddress(sig.signerPublicKey, scheme));
+        publicKeys.push(sig.signerPublicKey);
+      } else {
+        let recovered: string | undefined;
+        if (dto.signing !== SigningScheme.TON) {
+          try {
+            recovered = signatures.recoverPublicKey(sig.signature, dto, dto.prefix ?? "");
+          } catch {
+            recovered = undefined;
+          }
+        }
+        if (recovered) {
+          addresses.push(PublicKeyService.getUserAddress(recovered, scheme));
+          publicKeys.push(signatures.getCompactBase64PublicKey(recovered));
+        } else {
+          throw new MissingSignerError(sig.signature);
+        }
+      }
+    }
+
+    const profilesArr = await PublicKeyService.getUserProfiles(ctx, addresses);
+    const profileMap = new Map<string, UserProfileWithRoles>();
+    for (const p of profilesArr) {
+      if (p.ethAddress) {
+        profileMap.set(p.ethAddress, p);
+      }
+      if (p.tonAddress) {
+        profileMap.set(p.tonAddress, p);
+      }
+    }
+
+    const users: UserProfileWithRoles[] = [];
+
+    for (let i = 0; i < addresses.length; i++) {
+      const address = addresses[i];
+      let profile = profileMap.get(address);
+      let pk = publicKeys[i];
+
+      if (!profile) {
+        if (ctx.config.allowNonRegisteredUsers && pk) {
+          profile = PublicKeyService.getDefaultUserProfile(pk, scheme);
+        } else {
+          throw new UserNotRegisteredError(address);
+        }
+      }
+
+      if (!pk) {
+        const pkObj = await PublicKeyService.getPublicKey(ctx, profile.alias);
+        if (!pkObj) {
+          throw new PkMissingError(profile.alias);
+        }
+        pk = pkObj.publicKey;
+        publicKeys[i] = pk;
+      }
+
+      users.push(profile);
+    }
+
+    const pkList: string[] = publicKeys.map((p) => p as string);
+    if (!dto.verifySignatures(pkList)) {
+      const alias = users[0]?.alias ?? addresses[0];
+      throw new PkInvalidSignatureError(alias);
+    }
+
+    return users;
   }
 
   public static async registerUser(


### PR DESCRIPTION
## Summary
- batch fetch user profiles
- verify DTO multi-signatures via PublicKeyService helper
- streamline authentication to use shared signature validation

## Testing
- `npx nx run chaincode:test` *(fails: Nx modules missing)*
- `npx jest --config chaincode/jest.config.ts` *(fails: jest not found)*
- `npx tsc -p chaincode/tsconfig.lib.json` *(fails: chain-api build missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dcd02dec8330bd5ee30399a2230f