### PR TITLE
fix: validate signatures against declared signer

### DIFF
--- a/chaincode/src/contracts/authenticate.multisig.spec.ts
+++ b/chaincode/src/contracts/authenticate.multisig.spec.ts
@@ -1,10 +1,11 @@
 import { ChainCallDTO } from "@gala-chain/api";
 import { TestChaincode, TestChaincodeStub } from "@gala-chain/test";
 
+import { PkInvalidSignatureError } from "../services/PublicKeyError";
+import { GalaChainContext } from "../types";
 import { PublicKeyContract } from "./PublicKeyContract";
 import { authenticate } from "./authenticate";
 import { createRegisteredUser } from "./authenticate.testutils.spec";
-import { GalaChainContext } from "../types";
 
 describe("authenticate multisig", () => {
   it("aggregates multiple signers", async () => {
@@ -14,6 +15,7 @@ describe("authenticate multisig", () => {
 
     const dto = new ChainCallDTO();
     dto.sign(user1.privateKey);
+    dto.signerPublicKey = user2.publicKey;
     dto.addSignature(user2.privateKey);
 
     const ctx = new GalaChainContext({});
@@ -27,5 +29,22 @@ describe("authenticate multisig", () => {
     expect(result.users[0].alias).toBe(user1.alias);
     expect(result.users[1].alias).toBe(user2.alias);
     expect(ctx.callingUsers).toEqual(result.users);
+  });
+
+  it("rejects signatures that mismatch declared signer", async () => {
+    const chaincode = new TestChaincode([PublicKeyContract]);
+    const user1 = await createRegisteredUser(chaincode);
+    const user2 = await createRegisteredUser(chaincode);
+
+    const dto = new ChainCallDTO();
+    dto.sign(user1.privateKey);
+    dto.signerAddress = user2.ethAddress;
+    dto.addSignature(user1.privateKey);
+
+    const ctx = new GalaChainContext({});
+    const stub = new TestChaincodeStub([], chaincode.state, {});
+    ctx.setChaincodeStub(stub);
+
+    await expect(authenticate(ctx, dto, 2)).rejects.toThrow(PkInvalidSignatureError);
   });
 });


### PR DESCRIPTION
## Summary
- ensure each signature is validated against its declared signer
- cover valid and spoofed multi-signature authentication scenarios

## Testing
- `npx prettier --write chaincode/src/services/PublicKeyService.ts chaincode/src/contracts/authenticate.multisig.spec.ts`
- `npx nx run chaincode:test` *(fails: terminal crashed before output)*
- `npx eslint chaincode/src/services/PublicKeyService.ts chaincode/src/contracts/authenticate.multisig.spec.ts`
- `npx jest --config chaincode/jest.config.ts` *(fails: numerous TS errors)*
- `npx tsc -p chaincode/tsconfig.lib.json` *(fails: chain-api build missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e29385e083309a4c65c6e3ecf619