### PR TITLE
feat: validate multisig duplicates

### DIFF
--- a/chaincode/src/contracts/authenticate.ts
+++ b/chaincode/src/contracts/authenticate.ts
@@ -55,7 +55,9 @@ export async function authenticate(
 
   const usersWithRoles = await PublicKeyService.ensureSignaturesValid(ctx, dto);
 
-  const callingUsers: UserProfile[] = usersWithRoles.map((u) => {
+  const uniqueUsers = Array.from(new Map(usersWithRoles.map((u) => [u.alias, u])).values());
+
+  const callingUsers: UserProfile[] = uniqueUsers.map((u) => {
     const p = new UserProfile();
     p.alias = u.alias;
     p.ethAddress = u.ethAddress;
@@ -67,7 +69,14 @@ export async function authenticate(
   ctx.callingUsers = callingUsers;
 
   const first = callingUsers[0];
-  return { ...first, users: callingUsers, minSignatures };
+  return {
+    alias: first.alias,
+    ethAddress: first.ethAddress,
+    tonAddress: first.tonAddress,
+    roles: first.roles ?? [],
+    users: callingUsers,
+    minSignatures
+  };
 }
 
 export async function ensureIsAuthenticatedBy(

--- a/chaincode/src/services/PublicKeyError.ts
+++ b/chaincode/src/services/PublicKeyError.ts
@@ -12,7 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ConflictError, NotFoundError, UnauthorizedError } from "@gala-chain/api";
+import {
+  ConflictError,
+  NotFoundError,
+  UnauthorizedError,
+  ValidationFailedError
+} from "@gala-chain/api";
 
 export class PkExistsError extends ConflictError {
   constructor(user: string) {
@@ -55,6 +60,12 @@ export class PkInvalidSignatureError extends UnauthorizedError {
   constructor(user: string) {
     const message = `Signature is invalid. DTO should be signed by ${user} private key with secp256k1 algorithm`;
     super(message, { user });
+  }
+}
+
+export class DuplicateSignerError extends ValidationFailedError {
+  constructor(address: string) {
+    super(`Duplicate signer address detected: ${address}`, { address });
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent duplicate signer addresses in multisig validation
- dedupe calling users during authentication
- test multisig logic rejects duplicate signatures

## Testing
- `npx jest chaincode/src/contracts/authenticate.multisig.spec.ts chaincode/src/contracts/GalaTransaction.multisig.spec.ts --config chaincode/jest.config.ts --runInBand --watchAll=false` *(fails: Duplicate signer address detected / Missing role errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2085cb99c8330bab808aa209509aa