### PR TITLE
fix: preserve service caller identity

### DIFF
--- a/chaincode/src/contracts/authenticate.ts
+++ b/chaincode/src/contracts/authenticate.ts
@@ -47,8 +47,13 @@ export async function authenticate(
   if (!dto || !dto.signatures || dto.signatures.length === 0) {
     if (dto?.signerAddress?.startsWith("service|")) {
       const chaincode = dto.signerAddress.slice(8);
-      ctx.callingUsers = [];
-      return { ...(await authenticateAsOriginChaincode(ctx, dto, chaincode)), users: [], minSignatures };
+      const authResult = await authenticateAsOriginChaincode(ctx, dto, chaincode);
+      const serviceProfile = new UserProfile();
+      serviceProfile.alias = authResult.alias;
+      serviceProfile.ethAddress = authResult.ethAddress;
+      serviceProfile.roles = authResult.roles;
+      ctx.callingUsers = [serviceProfile];
+      return { ...authResult, users: [serviceProfile], minSignatures };
     }
 
     throw new MissingSignatureError();


### PR DESCRIPTION
## Summary
- populate `ctx.callingUsers` with authenticated service profile

## Testing
- `npx nx test chaincode` *(fails: Argument of type 'TestGalaChainContext' is not assignable to parameter of type 'GalaChainContext')*

------
https://chatgpt.com/codex/tasks/task_e_68b21bb0b9ec833080eee6c2c4ad6b61