### PR TITLE
fix: adjust JSON error expectation

### DIFF
--- a/chain-api/src/types/dtos.spec.ts
+++ b/chain-api/src/types/dtos.spec.ts
@@ -70,7 +70,9 @@ it("should parse TestDtoWithArray", async () => {
   expect(await getPlainOrError(TestDtoWithArray, valid)).toEqual({ playerIds: ["123"] });
   expect(await getPlainOrError(TestDtoWithArray, invalid1)).toEqual(failedArrayMatcher);
   expect(await getPlainOrError(TestDtoWithArray, invalid2)).toEqual(failedArrayMatcher);
-  expect(await getPlainOrError(TestDtoWithArray, invalid3)).toEqual("Unexpected end of JSON input");
+  expect(await getPlainOrError(TestDtoWithArray, invalid3)).toEqual(
+    "Unterminated string in JSON at position 16"
+  );
 });
 
 it("should parse TestDtoWithBigNumber", async () => {


### PR DESCRIPTION
## Summary
- align JSON parse error expectation with Node's current message

## Testing
- `NX_DAEMON=false npx nx test chain-connect --skip-nx-cache --output-style=stream`
- `NX_DAEMON=false npx nx test chain-test --skip-nx-cache --output-style=stream`
- `NX_DAEMON=false npx nx test chain-api --skip-nx-cache --output-style=stream`


------
https://chatgpt.com/codex/tasks/task_e_68b327656074833088e7ba766bbd2748